### PR TITLE
Retirar "sudo" de blue-radar.sh

### DIFF
--- a/blue-radar.sh
+++ b/blue-radar.sh
@@ -13,12 +13,12 @@ echo "3. Descripcion rapida de las dos herramientas."
 read -p "Elije la opcion que quieres(1-3): " numero
 case $numero in
     1)
-        sudo ./blue-radar-scanner.sh
+        ./blue-radar-scanner.sh
 esac
 
 case $numero in
     2)
-        sudo ./blue-radar-alert.sh
+        ./blue-radar-alert.sh
 esac
 
 case $numero in


### PR DESCRIPTION
Retirados los comandos sudo para llamar a blue-radar-scanner y blue-radar-alert, ya que al ser un script que exige su ejecución como root, usar sudo ya siendo root no es algo necesario ni tampoco util realmente.